### PR TITLE
Scaffolding based on redocly tooling

### DIFF
--- a/.github/workflows/redocly.yaml
+++ b/.github/workflows/redocly.yaml
@@ -1,0 +1,24 @@
+name: Redocly
+on:
+    push:
+    pull_request:
+jobs:
+    redocly:
+        runs-on: ubuntu-latest
+        name: Lint and build
+        container:
+            image: redocly/cli
+            volumes:
+                - .:/spec
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v4
+            - name: Check API specification
+              run: redocly lint ./yaml/toy.yaml
+            - name: Build generated documentation
+              run: redocly build-docs ./yaml/toy.yaml
+            - name: Store generated artifact
+              uses: actions/upload-artifact@v4
+              with:
+                  name: api-docs
+                  path: redoc-static.html

--- a/yaml/toy.yaml
+++ b/yaml/toy.yaml
@@ -1,0 +1,116 @@
+openapi: 3.0.3
+info:
+    title: Snapd REST API
+    license:
+        name: GPL-3.0
+        url: https://www.gnu.org/licenses/gpl-3.0.txt
+    description: |
+        The REST API provides access to snapd's state and many of its key functions,
+        as listed below.
+
+
+        For general information on how to use the API, including how to access it,
+        its requests and responses, results fields and error types, see [Using the
+        REST API](https://snapcraft.io/docs/using-the-api).
+    version: "0.1"
+servers:
+    - url: unix:///run/snapd.socket
+externalDocs:
+    url: https://snapcraft.io/docs
+    description: Snap and Snapcraft documentation
+paths:
+    /v2/aliases:
+        get:
+            operationId: getAliases
+            summary: Get the available app aliases
+            security: []
+            responses:
+                "200":
+                    description: A dictionary containing the aliases for each snap.
+                    content:
+                        application/json:
+                            schema:
+                                type: object
+                                properties:
+                                    status-code:
+                                        type: integer
+                                        description: |
+                                            The status-code property contains the HTTP
+                                        enum:
+                                            - 200
+                                    status:
+                                        type: string
+                                        description: |
+                                            The status property contains the textual representation of the "status-code" property.
+                                            For the "status-code" equal to 200, the "status" is always "OK"
+                                        enum:
+                                            - OK
+                                    type:
+                                        type: string
+                                        description: |
+                                            The type property indicates that this is a synchronous API response and the whole content
+                                            is now available. The result of the API call is in the result object. The value is always
+                                            "sync".
+                                        enum:
+                                            - sync
+                                    result:
+                                        type: object
+                                        description: |
+                                            The result object contains information about all the aliases in the system.
+                                        additionalProperties:
+                                            type: object
+                                            description: |
+                                                Each top-level property is a snap instance name. Typically snap instance is
+                                                the name of the snap, except when parallel-instances as used and the snap name
+                                                is followed by an underscore and then the instance key.
+                                            additionalProperties:
+                                                type: object
+                                                description: |
+                                                    Each top-level property under the snap name above, is the name of the actual alias.
+                                                    The alias is visible as a top-level command and is exposed on PATH in the system.
+                                                required:
+                                                    - command
+                                                    - status
+                                                properties:
+                                                    command:
+                                                        type: string
+                                                        description: |
+                                                            The name of the snap entry-point executable invoked by this alias.
+                                                            This is typically the name of the snap followed by dot and then the name
+                                                            of the application within the snap. It may also be just the name of the snap.
+                                                    status:
+                                                        type: string
+                                                        description: |
+                                                            Status describes the status of the alias. The value "maniual" indicates that the
+                                                            status was created manually by the user. The status "disabled" indicates the user
+                                                            manually removed the alias (it will not be re-created automatically by snapd).
+                                                            The status "auto" indictates that the alias was created automatically by snapd.
+                                                        enum:
+                                                            - auto
+                                                            - manual
+                                                            - disabled
+                                                    auto:
+                                                        type: string
+                                                        description: |
+                                                            The app the alias is for as assigned by an assertion
+                                                            (optional)
+                                                    manual:
+                                                        type: string
+                                                        description: |
+                                                            The app the alias is for if status is manual (optional).
+                                                            Overrides auto
+                "403":
+                    description: "Can this ever fail?"
+                    content:
+                        application/json:
+                            schema:
+                                type: object
+                                properties:
+                                    status:
+                                        type: integer
+                                    message:
+                                        type: string
+                                    kind:
+                                        type: string
+                                        enum:
+                                            - sync


### PR DESCRIPTION
Add `yaml/toy.yaml` with GET response from `/v2/aliases` and a redocly-based CI workflow.

I chose to use redocly since swagger-cli is a deprecated and archived and recommends migration to redocly: https://github.com/APIDevTools/swagger-cli?tab=readme-ov-file

I think our older schema wasn't quite up to the current standards as I had to make quite a lot of changes. Please have a look.