### PR TITLE
Add /v2/sections to the OpenAPI Specification

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -31,6 +31,8 @@ tags:
     description: Access is restricted to the root user.
   - name: OpenAccess
     description: Do not require the user to authenticate.
+  - name: Store
+    description: Interact with the store.
   - name: Synchronous
     description: Return the complete response synchronously.
   - name: Warnings

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -71,3 +71,5 @@ paths:
     $ref: './v2/paths/aliases.yaml'
   /v2/warnings:
     $ref: './v2/paths/warnings.yaml'
+  /v2/sections:
+    $ref: './v2/paths/sections.yaml'

--- a/v2/paths/sections.yaml
+++ b/v2/paths/sections.yaml
@@ -1,0 +1,44 @@
+# SPDX-License-Identifier: GPL-3.0
+
+get:
+  tags:
+    - OpenAccess
+    - Store
+    - Synchronous
+  summary: Get store sections
+  description: |-
+    Retrieves the list of available sections in the Snap Store.
+  operationId: getStoreSections
+  security: []
+  responses:
+    '200':
+      description: A synchronous response containing the names of the store sections.
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              status-code:
+                type: integer
+                enum:
+                  - 200
+              status:
+                type: string
+                enum:
+                  - "OK"
+              type:
+                type: string
+                enum:
+                  - "sync"
+              result:
+                type: array
+                description: An array containing the names of the store sections.
+                items:
+                  type: string
+                example:
+                  - featured
+                  - development
+                  - social
+                  - utilities
+    '4XX':
+      $ref: '../components/responses/InternalError.yaml'


### PR DESCRIPTION
Only file added is path describing /v2/sections.yaml route.