### PR TITLE
Add /v2/notices to OpenAPI Specification

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -35,6 +35,8 @@ tags:
     description: Interact with changes.
   - name: Interfaces
     description: Display and manage interactions between snaps.
+  - name: Notices
+    description: Interact with notices.
   - name: OpenAccess
     description: Do not require the user to authenticate.
   - name: Snaps

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -109,6 +109,8 @@ components:
       $ref: './v2/components/schemas/Log.yaml'
     Media:
       $ref: './v2/components/schemas/Media.yaml'
+    Notice:
+      $ref: './v2/components/schemas/Notice.yaml'
     Plug:
       $ref: './v2/components/schemas/Plug.yaml'
     PlugRef:
@@ -167,6 +169,8 @@ paths:
     $ref: './v2/paths/model.yaml'
   /v2/model/serial:
     $ref: './v2/paths/serial.yaml'
+  /v2/notices:
+    $ref: './v2/paths/notices.yaml'
   /v2/sections:
     $ref: './v2/paths/sections.yaml'
   /v2/snapshots:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -171,6 +171,8 @@ paths:
     $ref: './v2/paths/serial.yaml'
   /v2/notices:
     $ref: './v2/paths/notices.yaml'
+  /v2/notices{id}:
+    $ref: './v2/paths/notices-id.yaml'
   /v2/sections:
     $ref: './v2/paths/sections.yaml'
   /v2/snapshots:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -171,7 +171,7 @@ paths:
     $ref: './v2/paths/serial.yaml'
   /v2/notices:
     $ref: './v2/paths/notices.yaml'
-  /v2/notices{id}:
+  /v2/notices/{id}:
     $ref: './v2/paths/notices-id.yaml'
   /v2/sections:
     $ref: './v2/paths/sections.yaml'

--- a/v2/components/errors/ConflictError.yaml
+++ b/v2/components/errors/ConflictError.yaml
@@ -6,7 +6,8 @@ properties:
   message:
     type: string
     description: A human-readable error message explaining the conflict.
-    example: snap "alias-snap" has "manip" change in progress
+    enum:
+      - snap 'alias-snap' has 'manip' change in progress
   kind:
     type: string
     description: A machine-readable string identifying the error type.

--- a/v2/components/errors/ConflictError.yaml
+++ b/v2/components/errors/ConflictError.yaml
@@ -6,7 +6,7 @@ properties:
   message:
     type: string
     description: A human-readable error message explaining the conflict.
-    enum:
+    example:
       - snap 'alias-snap' has 'manip' change in progress
   kind:
     type: string

--- a/v2/components/errors/InternalServerError.yaml
+++ b/v2/components/errors/InternalServerError.yaml
@@ -6,4 +6,5 @@ properties:
   message:
     type: string
     description: A human-readable error message.
-    example: internal server error
+    enum:
+      - internal server error

--- a/v2/components/errors/MalformedRequestError.yaml
+++ b/v2/components/errors/MalformedRequestError.yaml
@@ -5,5 +5,5 @@ type: object
 properties:
   message:
     type: string
-    enum:
+    example:
       - cannot decode request body into an alias action

--- a/v2/components/errors/MalformedRequestError.yaml
+++ b/v2/components/errors/MalformedRequestError.yaml
@@ -5,4 +5,5 @@ type: object
 properties:
   message:
     type: string
-    example: cannot decode request body into an alias action
+    enum:
+      - cannot decode request body into an alias action

--- a/v2/components/errors/NotFoundError.yaml
+++ b/v2/components/errors/NotFoundError.yaml
@@ -5,6 +5,6 @@ type: object
 properties:
   message:
     type: string
-    example:
+    enum:
       - no snapshot set with the given ID
       - local snap has no icon

--- a/v2/components/errors/NotFoundError.yaml
+++ b/v2/components/errors/NotFoundError.yaml
@@ -5,6 +5,6 @@ type: object
 properties:
   message:
     type: string
-    enum:
+    example:
       - no snapshot set with the given ID
       - local snap has no icon

--- a/v2/components/errors/SnapNotInstalledError.yaml
+++ b/v2/components/errors/SnapNotInstalledError.yaml
@@ -13,7 +13,7 @@ properties:
   message:
     type: string
     description: Human-readable string describing the error.
-    example:
+    enum:
       - no state entry for key
       - snap 'ubuntu-frame' is not installed
   value:

--- a/v2/components/errors/SnapNotInstalledError.yaml
+++ b/v2/components/errors/SnapNotInstalledError.yaml
@@ -13,7 +13,7 @@ properties:
   message:
     type: string
     description: Human-readable string describing the error.
-    enum:
+    example:
       - no state entry for key
       - snap 'ubuntu-frame' is not installed
   value:

--- a/v2/components/responses/AccessDenied.yaml
+++ b/v2/components/responses/AccessDenied.yaml
@@ -35,4 +35,5 @@ content:
             message:
               type: string
               description: A human-readable error message.
-              example: access denied
+              enum:
+                - access denied

--- a/v2/components/responses/Forbidden.yaml
+++ b/v2/components/responses/Forbidden.yaml
@@ -31,4 +31,5 @@ content:
                 - auth-cancelled    # TODO follow up PR looking into kind enum
             message:
               type: string
-              example: cancelled
+              enum:
+                - cancelled

--- a/v2/components/schemas/Log.yaml
+++ b/v2/components/schemas/Log.yaml
@@ -6,17 +6,17 @@ properties:
   timestamp:
     type: string
     format: date-time
-    description: The timestamp of the log entry in RFC3339 format.
-    example: "2025-09-11T15:10:22.264675Z"
+    description: The timestamp of the log entry in RFC3339 UTC format.
+    example: 2025-09-11T15:10:22.264675Z
   message:
     type: string
     description: The content of the log message.
-    example: "Failed to get https://cloud-images.ubuntu.com/releases/streams/v1/index.json"
+    example: Failed to get https://cloud-images.ubuntu.com/releases/streams/v1/index.json
   sid:
     type: string
     description: The service identifier for the log entry.
-    example: "multipassd"
+    example: multipassd
   pid:
     type: string
     description: The process ID associated with the log entry.
-    example: "2062"
+    example: 2062

--- a/v2/components/schemas/Notice.yaml
+++ b/v2/components/schemas/Notice.yaml
@@ -7,12 +7,16 @@ properties:
   id:
     type: string
     description: The unique ID of the notice.
-    example: "67"
+    example: 67
   user-id:
-    type: string
+    type: integer
     nullable: true
-    description: The UID of the user who may view the notice, or null if public.
-    example: null
+    description: |-
+      The UID of the user who may view the notice, or null if public.
+      Represented by Snapd internally as a *uint32.
+    example: 
+      - null
+      - 0xFFEE1122
   type:
     type: string
     description: The type of the notice.
@@ -24,24 +28,24 @@ properties:
   key:
     type: string
     description: |-
-      A type-specific identifier for the notice, often corresponding to a change ID,
-      can also be the name of the snap associated with the notice.
-    example: "63"
+      An identifier which differentiates notices of this type.
+      Notices recorded with the type and key of an existing notice count as an occurrence of that notice.
+    example: 63
   first-occurred:
     type: string
     format: date-time
-    description: The timestamp of the first time this notice occurred (RFC3339 format).
-    example: "2025-09-08T17:29:40.829324752Z"
+    description: The timestamp of the first time this notice occurred (RFC3339 UTC format).
+    example: 2025-09-08T17:29:40.829324752Z
   last-occurred:
     type: string
     format: date-time
-    description: The timestamp of the last time this notice occurred (RFC3339 format).
-    example: "2025-09-10T14:30:23.055109521Z"
+    description: The timestamp of the last time this notice occurred (RFC3339 UTC format).
+    example: 2025-09-10T14:30:23.055109521Z
   last-repeated:
     type: string
     format: date-time
-    description: The timestamp of the last time this notice was repeated (RFC3339 format).
-    example: "2025-09-10T14:30:23.055109521Z"
+    description: The timestamp of the last time this notice was repeated (RFC3339 UTC format).
+    example: 2025-09-10T14:30:23.055109521Z
   occurrences:
     type: integer
     description: The number of times this notice has occurred.
@@ -51,12 +55,12 @@ properties:
     description: Additional data captured from the last occurrence.
     additionalProperties: true
     example:
-      kind: "alias"
+      kind: alias
   repeat-after:
     type: string
     description: A duration string after which the notice may be repeated (optional).
-    example: "1h30m"
+    example: 1h30m
   expire-after:
     type: string
     description: A duration string after which the notice may be deleted.
-    example: "168h0m0s"
+    example: 168h0m0s

--- a/v2/components/schemas/Notice.yaml
+++ b/v2/components/schemas/Notice.yaml
@@ -25,6 +25,8 @@ properties:
       - warning
       - refresh-inhibit
       - snap-run-inhibit
+      - interfaces-requests-prompt
+      - interfaces-requests-rule-update
   key:
     type: string
     description: |-

--- a/v2/components/schemas/Notice.yaml
+++ b/v2/components/schemas/Notice.yaml
@@ -13,40 +13,41 @@ properties:
     nullable: true
     description: |-
       The UID of the user who may view the notice, or null if public.
-      Represented by Snapd internally as a *uint32.
     example: 
       - null
       - 0xFFEE1122
   type:
-    type: string
-    description: The type of the notice.
-    enum:
-      - change-update
-      - warning
-      - refresh-inhibit
-      - snap-run-inhibit
-      - interfaces-requests-prompt
-      - interfaces-requests-rule-update
+    $ref: './NoticeType.yaml'
   key:
     type: string
     description: |-
-      An identifier which differentiates notices of this type.
-      Notices recorded with the type and key of an existing notice count as an occurrence of that notice.
-    example: 63
+      An identifier which differentiates notices of this type. Notices recorded
+      with the type and key of an existing notice count as an occurrence of that
+      notice.
+    example:
+      - 63
+      - 'the snapd apparmor service is disabled; snap applications will likely not start.'
+      - ABCDABCDABCDABCD
+      - '-'
+      - libreoffice
   first-occurred:
     type: string
     format: date-time
-    description: The timestamp of the first time this notice occurred (RFC3339 UTC format).
+    description: |-
+      The timestamp of the first time this notice occurred (RFC3339 UTC format).
     example: 2025-09-08T17:29:40.829324752Z
   last-occurred:
     type: string
     format: date-time
-    description: The timestamp of the last time this notice occurred (RFC3339 UTC format).
+    description: |-
+      The timestamp of the last time this notice occurred (RFC3339 UTC format).
     example: 2025-09-10T14:30:23.055109521Z
   last-repeated:
     type: string
     format: date-time
-    description: The timestamp of the last time this notice was repeated (RFC3339 UTC format).
+    description: |-
+      The timestamp of the last time this notice was repeated (RFC3339 UTC
+      format).
     example: 2025-09-10T14:30:23.055109521Z
   occurrences:
     type: integer
@@ -60,7 +61,8 @@ properties:
       kind: alias
   repeat-after:
     type: string
-    description: A duration string after which the notice may be repeated (optional).
+    description: |-
+      A duration string after which the notice may be repeated (optional).
     example: 1h30m
   expire-after:
     type: string

--- a/v2/components/schemas/Notice.yaml
+++ b/v2/components/schemas/Notice.yaml
@@ -19,10 +19,12 @@ properties:
       - change-update
       - warning
       - refresh-inhibit
-    example: "change-update"
+      - snap-run-inhibit
   key:
     type: string
-    description: A type-specific identifier for the notice, often corresponding to a change ID.
+    description: |-
+      A type-specific identifier for the notice, often corresponding to a change ID,
+      can also be the name of the snap associated with the notice.
     example: "63"
   first-occurred:
     type: string

--- a/v2/components/schemas/Notice.yaml
+++ b/v2/components/schemas/Notice.yaml
@@ -1,0 +1,59 @@
+# SPDX-License-Identifier: GPL-3.0
+
+type: object
+description: A notice recorded by snapd, such as a warning or change update.
+properties:
+  id:
+    type: string
+    description: The unique ID of the notice.
+    example: "67"
+  user-id:
+    type: string
+    nullable: true
+    description: The UID of the user who may view the notice, or null if public.
+    example: null
+  type:
+    type: string
+    description: The type of the notice.
+    enum:
+      - change-update
+      - warning
+      - refresh-inhibit
+    example: "change-update"
+  key:
+    type: string
+    description: A type-specific identifier for the notice, often corresponding to a change ID.
+    example: "63"
+  first-occurred:
+    type: string
+    format: date-time
+    description: The timestamp of the first time this notice occurred (RFC3339 format).
+    example: "2025-09-08T17:29:40.829324752Z"
+  last-occurred:
+    type: string
+    format: date-time
+    description: The timestamp of the last time this notice occurred (RFC3339 format).
+    example: "2025-09-10T14:30:23.055109521Z"
+  last-repeated:
+    type: string
+    format: date-time
+    description: The timestamp of the last time this notice was repeated (RFC3339 format).
+    example: "2025-09-10T14:30:23.055109521Z"
+  occurrences:
+    type: integer
+    description: The number of times this notice has occurred.
+    example: 4
+  last-data:
+    type: object
+    description: Additional data captured from the last occurrence.
+    additionalProperties: true
+    example:
+      kind: "alias"
+  repeat-after:
+    type: string
+    description: A duration string after which the notice may be repeated (optional).
+    example: "1h30m"
+  expire-after:
+    type: string
+    description: A duration string after which the notice may be deleted.
+    example: "168h0m0s"

--- a/v2/components/schemas/Notice.yaml
+++ b/v2/components/schemas/Notice.yaml
@@ -1,4 +1,5 @@
 # SPDX-License-Identifier: GPL-3.0
+# SPDX-FileCopyrightText: Canonical Ltd
 
 type: object
 description: A notice recorded by snapd, such as a warning or change update.

--- a/v2/components/schemas/NoticeType.yaml
+++ b/v2/components/schemas/NoticeType.yaml
@@ -1,0 +1,12 @@
+# SPDX-License-Identifier: GPL-3.0
+# SPDX-FileCopyrightText: Canonical Ltd
+
+type: string
+description: The type of the notice.
+enum:
+  - change-update
+  - warning
+  - refresh-inhibit
+  - snap-run-inhibit
+  - interfaces-requests-prompt
+  - interfaces-requests-rule-update

--- a/v2/components/schemas/Snapshot.yaml
+++ b/v2/components/schemas/Snapshot.yaml
@@ -15,24 +15,24 @@ properties:
   time:
     type: string
     format: date-time
-    description: The creation timestamp of the snapshot (RFC3339 format).
-    example: "2025-08-18T14:30:38.226662804-02:30"
+    description: The creation timestamp of the snapshot (RFC3339 UTC format).
+    example: 2025-08-18T14:30:38.226662804-02:30
   snap:
     type: string
     description: The name of the snap that was snapshotted.
-    example: "libreoffice"
+    example: libreoffice
   snap-id:
     type: string
     description: The unique store ID of the snap.
-    example: "CpUkI0qPIIBVRsjy49adNq4D6Ra72y4v"
+    example: CpUkI0qPIIBVRsjy49adNq4D6Ra72y4v
   revision:
     type: string
     description: The revision of the snap at the time of the snapshot.
-    example: "355"
+    example: 355
   version:
     type: string
     description: The version of the snap at the time of the a snapshot.
-    example: "25.2.5.2"
+    example: 25.2.5.2
   size:
     type: integer
     format: int64

--- a/v2/components/schemas/Warning.yaml
+++ b/v2/components/schemas/Warning.yaml
@@ -10,17 +10,22 @@ properties:
     type: string
     format: date-time
     description: The first time a message of this type was created (RFC3339 UTC format).
+    example: 2025-09-08T17:29:40.829324752Z
   last-seen:
     type: string
     format: date-time
     description: The last time a message of this type was created (RFC3339 UTC format).
+    example: 2025-09-08T17:34:40.829324752Z
   last-shown:
     type: string
     format: date-time
     description: The last time a message of this type was displayed to the user (RFC3339 UTC format).
+    example: 2025-09-08T17:34:40.829324752Z
   delete-after:
     type: string
-    description: A duration string like '1h30m'.
+    description: A duration string indicating how much time since this warning was last added that it should be deleted.
+    example: 1h30m
   repeat-after:
     type: string
     description: Duration after which the warning is repeated.
+    example: 30m

--- a/v2/components/schemas/Warning.yaml
+++ b/v2/components/schemas/Warning.yaml
@@ -6,20 +6,20 @@ properties:
   message:
     type: string
     description: The warnings message content.
-  first-seen:
+  first-added:
     type: string
     format: date-time
-    description: The first time a message of this type was created (RFC3339 UTC format).
+    description: The first time a warning with this message was created (RFC3339 UTC format).
     example: 2025-09-08T17:29:40.829324752Z
-  last-seen:
+  last-added:
     type: string
     format: date-time
-    description: The last time a message of this type was created (RFC3339 UTC format).
+    description: The last time a warning with this message was created (RFC3339 UTC format).
     example: 2025-09-08T17:34:40.829324752Z
   last-shown:
     type: string
     format: date-time
-    description: The last time a message of this type was displayed to the user (RFC3339 UTC format).
+    description: The last time this warning was displayed to the user (RFC3339 UTC format).
     example: 2025-09-08T17:34:40.829324752Z
   delete-after:
     type: string
@@ -27,5 +27,5 @@ properties:
     example: 1h30m
   repeat-after:
     type: string
-    description: Duration after which the warning is repeated.
+    description: Duration string indicating how much time since this warning was last shown that it should be shown again.
     example: 30m

--- a/v2/paths/aliases.yaml
+++ b/v2/paths/aliases.yaml
@@ -10,7 +10,7 @@ get:
     - Synchronous
   security: []
   responses:
-    '200':
+    200:
       description: A dictionary containing the aliases for each snap.
       content:
         application/json:
@@ -83,7 +83,7 @@ get:
                           description: |
                             The app the alias is for if status is manual.
                             Overrides auto
-    '4XX':
+    4XX:
       $ref: '../components/responses/InternalError.yaml'
 
 post:
@@ -118,20 +118,20 @@ post:
             snap:
               type: string
               description: The snap name to modify (optional for unalias).
-              example: 'moon-buggy'
+              example: moon-buggy
             app:
               type: string
               description: The app to modify (optional).
             alias:
               type: string
               description: The alias to modify.
-              example: 'foo'
+              example: foo
   responses:
-    '202':
+    202:
       $ref: '../components/responses/Accepted.yaml'
-    '400':
+    400:
       $ref: '../components/responses/BadRequest.yaml'
-    '401':
+    401:
       $ref: '../components/responses/AccessDenied.yaml'
-    '409':
+    409:
       $ref: '../components/responses/Conflict.yaml'

--- a/v2/paths/connections.yaml
+++ b/v2/paths/connections.yaml
@@ -32,7 +32,7 @@ get:
       schema:
         type: string
   responses:
-    '200':
+    200:
       description: A synchronous response containing the connection status of plugs and slots.
       content:
         application/json:
@@ -46,12 +46,12 @@ get:
               status:
                 type: string
                 enum:
-                  - "OK"
+                  - OK
               type:
                 type: string
                 enum:
-                  - "sync"
+                  - sync
               result:
                 $ref: '../components/schemas/ConnectionStatus.yaml'
-    '400':
+    400:
       $ref: '../components/responses/BadRequest.yaml'

--- a/v2/paths/connections.yaml
+++ b/v2/paths/connections.yaml
@@ -25,6 +25,7 @@ get:
       schema:
         type: string
         enum:
+          - ''
           - all
     - name: interface
       in: query

--- a/v2/paths/logs.yaml
+++ b/v2/paths/logs.yaml
@@ -29,15 +29,18 @@ get:
       description: Comma-seperated list of snap names to filter by.
       schema:
         type: string
-        example: "multipass,lxd"
+        example:
+          - multipass
+          - lxd
+          - multipass,lxd
   responses:
-    '200':
+    200:
       description: A stream of log messages. Each line is a self-contained JSON object.
       content:
         application/x-ndjson:
           schema:
             $ref: '../components/schemas/Log.yaml'
-    '400':
+    400:
       $ref: '../components/responses/BadRequest.yaml'
-    '403':
+    403:
       $ref: '../components/responses/Forbidden.yaml'

--- a/v2/paths/notices-id.yaml
+++ b/v2/paths/notices-id.yaml
@@ -21,7 +21,8 @@ get:
         example: 74
   responses:
     200:
-      description: A synchronous response containing the details of the requested notice.
+      description: |-
+        A synchronous response containing the details of the requested notice.
       content:
         application/json:
           schema:
@@ -33,11 +34,11 @@ get:
                   - 200
               status:
                 type: string
-                example:
+                enum:
                   - OK
               type:
                 type: string
-                example:
+                enum:
                    - sync
               result:
                 $ref: '../components/schemas/Notice.yaml'

--- a/v2/paths/notices-id.yaml
+++ b/v2/paths/notices-id.yaml
@@ -1,0 +1,41 @@
+# SPDX-License-Identifier: GPL-3.0
+
+get:
+  tags:
+    - OpenAccess
+    - Notices
+    - Synchronous
+  summary: Retrieve a specific system notice
+  description: |-
+    Retrieves a single notice by its unique ID.
+  operationId: getNoticeByID
+  security: []
+  parameters:
+    - name: id
+      in: path
+      required: true
+      description: The unique ID of the notice to retrieve.
+      schema:
+        type: string
+        example: "74"
+  responses:
+    '200':
+      description: A synchronous response containing the details of the requested notice.
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              status-code:
+                type: integer
+                example: 200
+              status:
+                type: string
+                example: "OK"
+              type:
+                type: string
+                example: "sync"
+              result:
+                $ref: '../components/schemas/Notice.yaml'
+    '404':
+      $ref: '../components/responses/NotFound.yaml'

--- a/v2/paths/notices-id.yaml
+++ b/v2/paths/notices-id.yaml
@@ -1,4 +1,5 @@
 # SPDX-License-Identifier: GPL-3.0
+# SPDX-FileCopyrightText: Canonical Ltd
 
 get:
   tags:

--- a/v2/paths/notices-id.yaml
+++ b/v2/paths/notices-id.yaml
@@ -18,9 +18,9 @@ get:
       description: The unique ID of the notice to retrieve.
       schema:
         type: string
-        example: "74"
+        example: 74
   responses:
-    '200':
+    200:
       description: A synchronous response containing the details of the requested notice.
       content:
         application/json:
@@ -29,14 +29,17 @@ get:
             properties:
               status-code:
                 type: integer
-                example: 200
+                enum:
+                  - 200
               status:
                 type: string
-                example: "OK"
+                example:
+                  - OK
               type:
                 type: string
-                example: "sync"
+                example:
+                   - sync
               result:
                 $ref: '../components/schemas/Notice.yaml'
-    '404':
+    404:
       $ref: '../components/responses/NotFound.yaml'

--- a/v2/paths/notices.yaml
+++ b/v2/paths/notices.yaml
@@ -36,7 +36,7 @@ get:
           example: 74
     - name: after
       in: query
-      description: If specified, only return notices with a last-repeated field greater than the specified time, which should be in RFC3339 UTC format.
+      description: If specified, only return notices with a 'last-repeated' field greater than the specified time, which should be in RFC3339 UTC format.
       schema:
         type: string
         format: date-time

--- a/v2/paths/notices.yaml
+++ b/v2/paths/notices.yaml
@@ -74,7 +74,7 @@ get:
         the 'user-id' parameter.
       schema:
         type: string
-        example:
+        enum:
           - all
   responses:
     200:

--- a/v2/paths/notices.yaml
+++ b/v2/paths/notices.yaml
@@ -20,20 +20,25 @@ get:
         types. The types parameter can include multiple types, notices matching
         any of the types are returned.
       schema:
-        $ref: '../components/schemas/NoticeType.yaml'
+        type: array
+        items:
+          $ref: '../components/schemas/NoticeType.yaml'
     - name: keys
       in: query
       description: If specified, only return notices with one of the given keys.
       schema:
         type: array
         items:
-          type: integer
-          example: 74
+          type: string
+          example:
+            - 74
+            - '-'
+            - libreoffice
     - name: after
       in: query
       description: |-
         If specified, only return notices with a 'last-repeated' field greater
-        than the specified time, which should be in RFC3339 UTC format.
+        than the specified time, in RFC3339 UTC format.
       schema:
         type: string
         format: date-time
@@ -107,7 +112,7 @@ post:
     - Synchronous
   summary: Create a notice
   description: |-
-    Create a notice. Currently, this is only used to create notices of
+    Create a notice. Currently, this can only be used to create notices of type
     'snap-run-inhibit'. Only the 'snap' command is allowed to create notices of
     that type.
   operationId: postNotices
@@ -130,7 +135,7 @@ post:
                 - add
             key:
               type: string
-              description: The name of the snap to inhibit.
+              description: The key of the notice to add.
             type:
               type: string
               description: The type of the notice to add.
@@ -165,7 +170,7 @@ post:
                   id:
                     type: string
                     description: |-
-                      The ID of the operation.
+                      The ID of the newly-created notice.
                     example:
                       - 74
 

--- a/v2/paths/notices.yaml
+++ b/v2/paths/notices.yaml
@@ -1,4 +1,5 @@
 # SPDX-License-Identifier: GPL-3.0
+# SPDX-FileCopyrightText: Canonical Ltd
 
 get:
   tags:

--- a/v2/paths/notices.yaml
+++ b/v2/paths/notices.yaml
@@ -84,3 +84,70 @@ get:
                   $ref: '../components/schemas/Notice.yaml'
     '4XX':
       $ref: '../components/responses/InternalError.yaml'
+
+post:
+  tags:
+    - Notices
+    - OpenAccess
+    - Synchronous
+  summary: Create a notice
+  description: |-
+    Create a notice.
+  operationId: postNotices
+  security: []
+  requestBody:
+    required: true
+    content:
+      application/json:
+        schema:
+          type: object
+          required:
+            - action
+            - key
+            - type
+          properties:
+            action:
+              type: string
+              description: The action to perform.
+              enum: 
+                - "add"
+            key:
+              type: string
+              description: The name of the snap to inhibit.
+            type:
+              type: string
+              description: The type of the notice to add.
+              enum:
+                - "snap-run-inhibit"
+  responses:
+    '200':
+      description: A synchronous response indicating success.
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              status-code:
+                type: integer
+                enum: 
+                  - 200
+              status:
+                type: string
+                enum:
+                  - "OK"
+              type:
+                type: string
+                enum:
+                  - "sync"
+              result:
+                type: object
+                description: |
+                  The result object contains information about the response to the request.
+                additionalProperties:
+                  type: string
+                  description: |
+                    The ID of the operation.
+                  example: "74"
+
+    '400':
+      $ref: '../components/responses/BadRequest.yaml'

--- a/v2/paths/notices.yaml
+++ b/v2/paths/notices.yaml
@@ -23,17 +23,24 @@ get:
           - change-update
           - warning
           - refresh-inhibit
+          - snap-run-inhibit
+          - interfaces-requests-prompt
+          - interfaces-requests-rule-update
     - name: keys
       in: query
       description: If specified, only return notices with one of the given keys.
       schema:
-        type: string
+        type: array
+        items:
+          type: integer
+          example: 74
     - name: after
       in: query
-      description: If specified, only return notices with a LastRepeated field greater than the specified time, which should be in RFC3339 format.
+      description: If specified, only return notices with a last-repeated field greater than the specified time, which should be in RFC3339 UTC format.
       schema:
         type: string
         format: date-time
+        example: 2025-09-08T17:29:40.829324752Z
     - name: timeout
       in: query
       description: |-
@@ -42,25 +49,30 @@ get:
         This allows the user to use long-polling to be notified immediately when a new notice is recorded.
       schema:
         type: string
+        example: 7m30s
     - name: user-id
       in: query
       description: |-
         Admin only.
         Instead of returning notices associated with the user who initiated the API request, return notices associated with the given UID.
-        Public notices are still returned, as before.
+        Public notices are still returned, as before. Cannot be used with the 'users' parameter.
       schema:
-        type: string
+        type: integer
+        example: 1000
     - name: users
       in: query
       description: |-
         Admin only.
-        Value must be all. Return notices associated with all users, instead of just the user which initiated the API request.
-        Cannot be used with the user-id parameter.
+        Value must be 'all'. Return notices associated with all users, instead of just the user which initiated the API request.
+        Cannot be used with the 'user-id' parameter.
       schema:
         type: string
-
+        nullable: true
+        example:
+          - null
+          - all
   responses:
-    '200':
+    200:
       description: A synchronous response containing a list of notices matching the filter criteria.
       content:
         application/json:
@@ -74,16 +86,16 @@ get:
               status:
                 type: string
                 enum:
-                  - "OK"
+                  - OK
               type:
                 type: string
                 enum:
-                  - "sync"
+                  - sync
               result:
                 type: array
                 items:
                   $ref: '../components/schemas/Notice.yaml'
-    '4XX':
+    4XX:
       $ref: '../components/responses/InternalError.yaml'
 
 post:
@@ -111,7 +123,7 @@ post:
               type: string
               description: The action to perform.
               enum: 
-                - "add"
+                - add
             key:
               type: string
               description: The name of the snap to inhibit.
@@ -119,9 +131,9 @@ post:
               type: string
               description: The type of the notice to add.
               enum:
-                - "snap-run-inhibit"
+                - snap-run-inhibit
   responses:
-    '200':
+    200:
       description: A synchronous response indicating success.
       content:
         application/json:
@@ -135,11 +147,11 @@ post:
               status:
                 type: string
                 enum:
-                  - "OK"
+                  - OK
               type:
                 type: string
                 enum:
-                  - "sync"
+                  - sync
               result:
                 type: object
                 description: |
@@ -148,7 +160,7 @@ post:
                   type: string
                   description: |
                     The ID of the operation.
-                  example: "74"
+                  example: 74
 
-    '400':
+    400:
       $ref: '../components/responses/BadRequest.yaml'

--- a/v2/paths/notices.yaml
+++ b/v2/paths/notices.yaml
@@ -1,0 +1,86 @@
+# SPDX-License-Identifier: GPL-3.0
+
+get:
+  tags:
+    - Notices
+    - OpenAccess
+    - Synchronous
+  summary: Retrieve system notices
+  description: |-
+    Retrieves notices for the current user and any public notices, with optional filtering.
+  operationId: getNotices
+  security: []
+  parameters:
+    - name: types
+      in: query
+      description: |-
+        If types is specified, only return notices with types matching the given types.
+        The types parameter can include multiple types, notices matching any of the types are returned.
+      schema:
+        type: string
+        enum:
+          - change-update
+          - warning
+          - refresh-inhibit
+    - name: keys
+      in: query
+      description: If specified, only return notices with one of the given keys.
+      schema:
+        type: string
+    - name: after
+      in: query
+      description: If specified, only return notices with a LastRepeated field greater than the specified time, which should be in RFC3339 format.
+      schema:
+        type: string
+        format: date-time
+    - name: timeout
+      in: query
+      description: |-
+        If there are notices matching the filter which have already been recorded, these notices are returned immediately.
+        Otherwise, if timeout is specified, wait up to the given duration for any new notices matching the filter to be recorded.
+        This allows the user to use long-polling to be notified immediately when a new notice is recorded.
+      schema:
+        type: string
+    - name: user-id
+      in: query
+      description: |-
+        Admin only.
+        Instead of returning notices associated with the user who initiated the API request, return notices associated with the given UID.
+        Public notices are still returned, as before.
+      schema:
+        type: string
+    - name: users
+      in: query
+      description: |-
+        Admin only.
+        Value must be all. Return notices associated with all users, instead of just the user which initiated the API request.
+        Cannot be used with the user-id parameter.
+      schema:
+        type: string
+
+  responses:
+    '200':
+      description: A synchronous response containing a list of notices matching the filter criteria.
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              status-code:
+                type: integer
+                enum:
+                  - 200
+              status:
+                type: string
+                enum:
+                  - "OK"
+              type:
+                type: string
+                enum:
+                  - "sync"
+              result:
+                type: array
+                items:
+                  $ref: '../components/schemas/Notice.yaml'
+    '4XX':
+      $ref: '../components/responses/InternalError.yaml'

--- a/v2/paths/notices.yaml
+++ b/v2/paths/notices.yaml
@@ -8,24 +8,19 @@ get:
     - Synchronous
   summary: Retrieve system notices
   description: |-
-    Retrieves notices for the current user and any public notices, with optional filtering.
+    Retrieves notices for the current user and any public notices, with optional
+    filtering.
   operationId: getNotices
-  security: []
+  security: []    # TODO Not fully described in machine-readable format, normally OpenAccess unless certain parameters are used
   parameters:
     - name: types
       in: query
       description: |-
-        If types is specified, only return notices with types matching the given types.
-        The types parameter can include multiple types, notices matching any of the types are returned.
+        If types is specified, only return notices with types matching the given
+        types. The types parameter can include multiple types, notices matching
+        any of the types are returned.
       schema:
-        type: string
-        enum:
-          - change-update
-          - warning
-          - refresh-inhibit
-          - snap-run-inhibit
-          - interfaces-requests-prompt
-          - interfaces-requests-rule-update
+        $ref: '../components/schemas/NoticeType.yaml'
     - name: keys
       in: query
       description: If specified, only return notices with one of the given keys.
@@ -36,7 +31,9 @@ get:
           example: 74
     - name: after
       in: query
-      description: If specified, only return notices with a 'last-repeated' field greater than the specified time, which should be in RFC3339 UTC format.
+      description: |-
+        If specified, only return notices with a 'last-repeated' field greater
+        than the specified time, which should be in RFC3339 UTC format.
       schema:
         type: string
         format: date-time
@@ -44,9 +41,11 @@ get:
     - name: timeout
       in: query
       description: |-
-        If there are notices matching the filter which have already been recorded, these notices are returned immediately.
-        Otherwise, if timeout is specified, wait up to the given duration for any new notices matching the filter to be recorded.
-        This allows the user to use long-polling to be notified immediately when a new notice is recorded.
+        If there are notices matching the filter which have already been
+        recorded, these notices are returned immediately. Otherwise, if timeout
+        is specified, wait up to the given duration for any new notices matching
+        the filter to be recorded. This allows the user to use long-polling to
+        be notified immediately when a new notice is recorded.
       schema:
         type: string
         example: 7m30s
@@ -54,8 +53,10 @@ get:
       in: query
       description: |-
         Admin only.
-        Instead of returning notices associated with the user who initiated the API request, return notices associated with the given UID.
-        Public notices are still returned, as before. Cannot be used with the 'users' parameter.
+        Instead of returning notices associated with the user who initiated the
+        API request, return notices associated with the given UID. Public
+        notices are still returned, as before. Cannot be used with the 'users'
+        parameter.
       schema:
         type: integer
         example: 1000
@@ -63,17 +64,18 @@ get:
       in: query
       description: |-
         Admin only.
-        Value must be 'all'. Return notices associated with all users, instead of just the user which initiated the API request.
-        Cannot be used with the 'user-id' parameter.
+        Value must be 'all'. Return notices associated with all users, instead
+        of just the user which initiated the API request. Cannot be used with
+        the 'user-id' parameter.
       schema:
         type: string
-        nullable: true
         example:
-          - null
           - all
   responses:
     200:
-      description: A synchronous response containing a list of notices matching the filter criteria.
+      description: |-
+        A synchronous response containing a list of notices matching the filter
+        criteria.
       content:
         application/json:
           schema:
@@ -105,7 +107,9 @@ post:
     - Synchronous
   summary: Create a notice
   description: |-
-    Create a notice.
+    Create a notice. Currently, this is only used to create notices of
+    'snap-run-inhibit'. Only the 'snap' command is allowed to create notices of
+    that type.
   operationId: postNotices
   security: []
   requestBody:
@@ -154,13 +158,16 @@ post:
                   - sync
               result:
                 type: object
-                description: |
-                  The result object contains information about the response to the request.
-                additionalProperties:
-                  type: string
-                  description: |
-                    The ID of the operation.
-                  example: 74
+                description: |-
+                  The result object contains information about the response to
+                  the request.
+                properties:
+                  id:
+                    type: string
+                    description: |-
+                      The ID of the operation.
+                    example:
+                      - 74
 
     400:
       $ref: '../components/responses/BadRequest.yaml'

--- a/v2/paths/sections.yaml
+++ b/v2/paths/sections.yaml
@@ -12,7 +12,7 @@ get:
   operationId: getStoreSections
   security: []
   responses:
-    '200':
+    200:
       description: A synchronous response containing the names of the store sections.
       content:
         application/json:
@@ -26,11 +26,11 @@ get:
               status:
                 type: string
                 enum:
-                  - "OK"
+                  - OK
               type:
                 type: string
                 enum:
-                  - "sync"
+                  - sync
               result:
                 type: array
                 description: An array containing the names of the store sections.
@@ -41,5 +41,5 @@ get:
                   - development
                   - social
                   - utilities
-    '4XX':
+    4XX:
       $ref: '../components/responses/InternalError.yaml'

--- a/v2/paths/snapshots-export.yaml
+++ b/v2/paths/snapshots-export.yaml
@@ -21,16 +21,16 @@ get:
         type: integer
         example: 2
   responses:
-    '200':
+    200:
       description: A gzipped tar archive (.tgz) of the exported snapshot set.
       content:
         application/gzip:
           schema:
             type: string
             format: binary
-    '400':
+    400:
       $ref: '../components/responses/BadRequest.yaml'
-    '401':
+    401:
       $ref: '../components/responses/AccessDenied.yaml'
-    '404':
+    404:
       $ref: '../components/responses/NotFound.yaml'

--- a/v2/paths/snapshots.yaml
+++ b/v2/paths/snapshots.yaml
@@ -12,7 +12,7 @@ get:
   operationId: listSnapshots
   security: []
   responses:
-    '200':
+    200:
       description: A synchronous response containing a list of snapshot sets.
       content:
         application/json:
@@ -21,18 +21,21 @@ get:
             properties:
               status-code:
                 type: integer
-                example: 200
+                enum:
+                  - 200
               status:
                 type: string
-                example: "OK"
+                enum:
+                  - OK
               type:
                 type: string
-                example: "sync"
+                enum:
+                  - sync
               result:
                 type: array
                 items:
                   $ref: '../components/schemas/SnapshotSet.yaml'
-    '4XX':
+    4XX:
       $ref: '../components/responses/InternalError.yaml'
 
 post:
@@ -83,11 +86,11 @@ post:
           format: binary
           description: A tar archive of an exported snapshot, used only to import a snapshot with the 'import' action.
   responses:
-    '202':
+    202:
       $ref: '../components/responses/Accepted.yaml'
-    '400':
+    400:
       $ref: '../components/responses/BadRequest.yaml'
-    '401':
+    401:
       $ref: '../components/responses/AccessDenied.yaml'
-    '404':
+    404:
       $ref: '../components/responses/NotFound.yaml'

--- a/v2/paths/warnings.yaml
+++ b/v2/paths/warnings.yaml
@@ -14,13 +14,16 @@ get:
   parameters:
     - name: select
       in: query
-      required: false
-      description: Retrieve all warnings, or just pending ones.
+      description: |-
+        Retrieve specific warnings. The default only shows pending warnings.
+        All shows warnings that haven't expired or been cleaned.
       schema:
         type: string
         enum:
+          - ''
           - all
           - pending
+        default: pending
   responses:
     200:
       description: A synchronous response containing a list of warnings.

--- a/v2/paths/warnings.yaml
+++ b/v2/paths/warnings.yaml
@@ -11,8 +11,18 @@ get:
     Retrieves the current warnings in snapd.
   operationId: getWarnings
   security: []
+  parameters:
+    - name: select
+      in: query
+      required: false
+      description: Retrieve all warnings, or just pending ones.
+      schema:
+        type: string
+        enum:
+          - all
+          - pending
   responses:
-    '200':
+    200:
       description: A synchronous response containing a list of warnings.
       content:
         application/json:
@@ -26,18 +36,18 @@ get:
               status:
                 type: string
                 enum:
-                  - "OK"
+                  - OK
               type:
                 type: string
                 enum:
-                  - "sync"
+                  - sync
               result:
                 type: array
                 items:
                   $ref: '../components/schemas/Warning.yaml'
 
-    '4XX':
-      $ref: '../components/responses/InternalError.yaml'
+    400:
+      $ref: '../components/responses/BadRequest.yaml'
 
 post:
   tags:
@@ -64,13 +74,14 @@ post:
             action:
               type: string
               enum: 
-                - "okay"
+                - okay
             timestamp:
               type: string
               format: date-time
               description: Time to clear warnings before (RFC3339 UTC format).
+              example: 2025-09-08T17:29:40.829324752Z
   responses:
-    '200':
+    200:
       description: A synchronous response indicating success.
       content:
         application/json:
@@ -84,14 +95,14 @@ post:
               status:
                 type: string
                 enum:
-                  - "OK"
+                  - OK
               type:
                 type: string
                 enum:
-                  - "sync"
+                  - sync
               result:
                 type: integer
                 description: The number of warnings cleared.
                 example: 0
-    '400':
+    400:
       $ref: '../components/responses/BadRequest.yaml'


### PR DESCRIPTION
Add Notice object to schema, add path describing /v2/notices route.

From SNAPDENG-35548