### PR TITLE
Add Path Describing /v2/interfaces to OpenAPI Specification.

### DIFF
--- a/v2/components/schemas/Interface.yaml
+++ b/v2/components/schemas/Interface.yaml
@@ -1,0 +1,22 @@
+# SPDX-License-Identifier: GPL-3.0
+# SPDX-FileCopyrightText: Canonical Ltd
+
+type: object
+properties:
+  plugs:
+    type: array
+    format: date-time
+    description: The timestamp of the log entry in RFC3339 format.
+    example: "2025-09-11T15:10:22.264675Z"
+  slots:
+    type: array
+    description: The content of the log message.
+    example: "Failed to get https://cloud-images.ubuntu.com/releases/streams/v1/index.json"
+  sid:
+    type: string
+    description: The service identifier for the log entry.
+    example: "multipassd"
+  pid:
+    type: string
+    description: The process ID associated with the log entry.
+    example: "2062"

--- a/v2/paths/interfaces.yaml
+++ b/v2/paths/interfaces.yaml
@@ -1,0 +1,114 @@
+# SPDX-License-Identifier: GPL-3.0
+# SPDX-FileCopyrightText: Canonical Ltd
+
+get:
+  tags:
+    - Interfaces
+    - OpenAccess
+    - Synchronous
+  summary: Get available interfaces
+  description: |-
+    Retrieves the available interfaces and their associated metadata.
+  operationId: getInterfaces
+  security: []
+  parameters:
+    - name: select
+      in: query
+      description: |-
+        Set to all to retrieve all interfaces, or connected to only return connected interfaces
+        (if this parameter is omitted then the call returns the legacy format that should be no longer used).
+      schema:
+        type: string
+        enum:
+          - all
+          - connected
+    - name: slots
+      in: query
+      description: If set to true, slot information will be returned.
+      schema:
+        type: boolean
+    - name: plugs
+      in: query
+      description: If set to true, plug information will be returned.
+      schema:
+        type: boolean
+    - name: doc
+      in: query
+      description: If set to true, interface documentation will be returned.
+      schema:
+        type: boolean
+    - name: names
+      in: query
+      description: If given, then only interfaces that match the comma separated names are returned.
+      schema:
+        type: string
+  responses:
+    200:
+      description: A synchronous response containing a list of snapshot sets.
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              status-code:
+                type: integer
+                example: 200
+              status:
+                type: string
+                example: OK
+              type:
+                type: string
+                example: sync
+              result:
+                type: object
+                properties:
+                  plugs:
+                    type: array
+                    description: A list of plugs on the system matching the search criteria.
+                    items:
+                      $ref: '../components/schemas/Plug.yaml'
+
+                  slots:
+                    type: array
+                    description: A list of slots on the system matching the search criteria.
+                    items:
+                      $ref: '../components/schemas/Slot.yaml'
+    4XX:
+      $ref: '../components/responses/InternalError.yaml'
+
+post:
+  tags:
+    - Asynchronous
+    - AuthenticationRequired
+    - Interfaces
+  summary: Issue an action to the interface system
+  description: |-
+    Retrieves the available interfaces and their associated metadata.
+  operationId: postInterfaces
+  security:
+    - PeerAuth: []
+  parameters:
+    - name: action
+      in: query
+      description: Action to perform.
+      schema:
+        type: string
+        enum:
+          - connect
+          - disconnect
+    - name: slots
+      in: query
+      description: Array of slots to connect to. Each slot is referred to by the snap it is part of and the name of the slot
+      schema:
+        type: string
+    - name: plugs
+      in: query
+      description: Array of plugs to connect. Each plug is referred to by the snap it is part of and the name of the plug
+      schema:
+        type: string
+  responses:
+    202:
+      $ref: '../components/responses/Accepted.yaml'
+    400:
+      $ref: '../components/responses/BadRequest.yaml'
+


### PR DESCRIPTION
The output I recieved from snap debug API differed signifcantly from the original documentation. It also seems some of the query parameters don't work, as even when filtering ?names=libreoffice, the output is still too vast to capture in the terminal output.

https://snapcraft.io/docs/snapd-api#heading--interfaces