### PR TITLE
Add /v2/apps to OpenAPI Specification

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -71,6 +71,8 @@ components:
     SnapNotInstalledError:
       $ref: './v2/components/errors/SnapNotInstalledError.yaml'
 
+    App:
+      $ref: './v2/components/schemas/App.yaml'
     Connection:
       $ref: './v2/components/schemas/Connection.yaml'
     ConnectionStatus:
@@ -97,6 +99,8 @@ components:
 paths:
   /v2/aliases:
     $ref: './v2/paths/aliases.yaml'
+  /v2/apps:
+    $ref: './v2/paths/apps.yaml'
   /v2/connections:
     $ref: './v2/paths/connections.yaml'
   /v2/logs:

--- a/v2/components/schemas/App.yaml
+++ b/v2/components/schemas/App.yaml
@@ -1,0 +1,55 @@
+# SPDX-License-Identifier: GPL-3.0
+# SPDX-FileCopyrightText: Canonical Ltd
+
+type: object
+description: Represents a single application provided by a snap.
+properties:
+  snap:
+    type: string
+    description: The snap providing the app (optional).
+  name:
+    type: string
+    description: The name of the app.
+  desktop-file:
+    type: string
+    description: The desktop file for the app (optional).
+  daemon:
+    type: string
+    description: The daemon type, if the app is a service (optional).
+    example: simple
+  enabled:
+    type: boolean
+    description: True if the app is an enabled service (optional).
+  active:
+    type: boolean
+    description: True if the app is an active service (optional).
+  common-id:
+    type: string
+    description: Common ID associated with this app (optional).
+  activators:
+    type: array
+    description: Details about service activators, such as sockets (optional).
+    items:
+      type: object
+      properties:
+        Name:
+          type: string
+        Type:
+          type: string
+        Active:
+          type: boolean
+        Enabled:
+          type: boolean
+example:
+  - snap: spotify
+    name: spotify
+    desktop-file": /path/to/file.desktop
+  - snap: lxd
+    name: daemon
+    daemon: simple
+    enabled: true
+    activators:
+      - Name: unix
+        Type: socket
+        Active: true
+        Enabled: true

--- a/v2/paths/apps.yaml
+++ b/v2/paths/apps.yaml
@@ -1,0 +1,116 @@
+# SPDX-License-Identifier: GPL-3.0
+# SPDX-FileCopyrightText: Canonical Ltd
+
+get:
+  tags:
+    - Apps
+    - OpenAccess
+    - Synchronous
+  summary: List available apps
+  description: |-
+    Lists applications available from installed snaps. Can be filtered by services or snap names.
+  operationId: listApps
+  security: []
+  parameters:
+    - name: select
+      in: query
+      description: Limit which apps are returned.
+      schema:
+        type: string
+        enum:
+          - service
+        example: service
+    - name: names
+      in: query
+      description: Comma-separated list of snap names to get apps for.
+      schema:
+        type: string
+        example: spotify,lxd
+  responses:
+    200:
+      description: A synchronous response containing the connection status of plugs and slots.
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              status-code:
+                type: integer
+                enum:
+                  - 200
+              status:
+                type: string
+                enum:
+                  - OK
+              type:
+                type: string
+                enum:
+                  - sync
+              result:
+                $ref: '../components/schemas/App.yaml'
+    4XX:
+      $ref: '../components/responses/InternalError.yaml'
+
+post:
+  tags:
+    - Apps
+    - Asynchronous
+    - AuthenticationRequired
+  summary: Modify attributes of applications
+  description: |-
+    Perform actions like start, stop, or restart on snap applications, typically services.
+  operationId: modifyApps
+  security:
+    - macaroonAuth: []
+  requestBody:
+    description: The action to perform on one or more applications.
+    required: true
+    content:
+      application/json:
+        schema:
+          type: object
+          required:
+            - action
+            - names
+          properties:
+            action:
+              type: string
+              description: |-
+                The action to perform. 
+                As these actions only work for services, the names provided must resolve to at least one service.
+              enum:
+                - stop
+                - start
+                - restart
+            names:
+              type: array
+              description: A list of names of snaps (e.g. "lxd") or specific apps (e.g. "lxd.daemon") to operate on.
+              items:
+                type: string
+              example:
+                - [lxd]
+                - [lxd, spotify]
+            enable:
+              type: boolean
+              description: When action is 'start', arranges to have the service start at system boot.
+              default: false
+            disable:
+              type: boolean
+              description: When action is 'stop', arranges to no longer start the service at system boot.
+              default: false
+            reload:
+              type: boolean
+              description: When action is 'restart', tries to reload the service if it supports it; otherwise, it performs a full restart.
+              default: false
+        example:
+          action: stop
+          names: [lxd]
+  responses:
+    202:
+      $ref: '../components/responses/Accepted.yaml'
+    400:
+      $ref: '../components/responses/BadRequest.yaml'
+    401:
+      $ref: '../components/responses/AccessDenied.yaml'
+    404:
+      $ref: '../components/responses/NotFound.yaml'


### PR DESCRIPTION
- add App.yaml schema describing app object
- add apps.yaml path describing /v2/apps route.

https://snapcraft.io/docs/snapd-api#heading--apps