### PR TITLE
Add /v2/users to OpenAPI Specification

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -129,6 +129,8 @@ components:
       $ref: './v2/components/schemas/SystemInfo.yaml'
     Task:
       $ref: './v2/components/schemas/Task.yaml'
+    User:
+      $ref: './v2/components/schemas/User.yaml'
     Warning:
       $ref: './v2/components/schemas/Warning.yaml'
 
@@ -161,5 +163,7 @@ paths:
     $ref: './v2/paths/snapshots-export.yaml'
   /v2/system-info:
     $ref: './v2/paths/system-info.yaml'
+  /v2/users:
+    $ref: './v2/paths/users.yaml'
   /v2/warnings:
     $ref: './v2/paths/warnings.yaml'

--- a/v2/components/schemas/User.yaml
+++ b/v2/components/schemas/User.yaml
@@ -1,0 +1,19 @@
+# SPDX-License-Identifier: GPL-3.0
+# SPDX-FileCopyrightText: Canonical Ltd
+
+type: object
+description: Represents a user account on the system.
+properties:
+  id:
+    type: integer
+    description: The unique numeric ID for this user account.
+    example: 1
+  username:
+    type: string
+    description: The local username associated with this account.
+    example: 'lp-username'
+  email:
+    type: string
+    format: email
+    description: The email address associated with this account.
+    example: 'first-name.last-name@example.com'

--- a/v2/paths/users.yaml
+++ b/v2/paths/users.yaml
@@ -1,0 +1,78 @@
+# SPDX-License-Identifier: GPL-3.0
+# SPDX-FileCopyrightText: Canonical Ltd
+
+get:
+  tags:
+    - Root
+    - Sync
+    - Users
+  summary: Get user accounts
+  description: |-
+    Get information on user accounts on the system.
+  operationId: getUsers
+  security:
+    - PeerAuth: []
+  responses:
+    200:
+      description: An array of user account information.
+      content:
+        application/json:
+          schema:
+            type: array
+            items:
+              $ref: '../components/schemas/User.yaml'
+    400:
+      $ref: '../components/responses/BadRequest.yaml'
+
+post:
+  tags:
+    - Root
+    - Sync
+    - Users
+  summary: Manage users
+  description: |-
+    Create or remove local users on the system.
+  operationId: manageUsers
+  security:
+    - PeerAuth: []
+  requestBody:
+    required: true
+    content:
+      application/json:
+        schema:
+          type: object
+          required:
+            - action
+          properties:
+            action:
+              type: string
+              enum: [create, remove]
+            email:
+              type: string
+              format: email
+            username:
+              type: string
+            sudoer:
+              type: boolean
+              default: false
+            known:
+              type: boolean
+              default: false
+  responses:
+    200:
+      description: A list of objects with the created user details.
+      content:
+        application/json:
+          schema:
+            type: array
+            items:
+              type: object
+              properties:
+                username:
+                  type: string
+                ssh-keys:
+                  type: array
+                  items:
+                    type: string
+    400:
+      $ref: '../components/responses/BadRequest.yaml'


### PR DESCRIPTION
These were tagged as root auth in the existing documentation, but I don't understand the difference between the ones previously labelled with authentication being required and requiring the root authentication. When using the endpoints using snap debug api, there seems to be no observable difference to me.